### PR TITLE
Add labels documentation

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1335,7 +1335,7 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 	flTree := cmd.Bool([]string{"#t", "#tree", "#-tree"}, false, "Output graph in tree format")
 
 	flFilter := opts.NewListOpts(nil)
-	cmd.Var(&flFilter, []string{"f", "-filter"}, "Provide filter values (i.e., 'dangling=true')")
+	cmd.Var(&flFilter, []string{"f", "-filter"}, "Provide filter values. Valid filters:\ndangling=true - unlabeled images with no children\nlabel=<key> or label=<key>=<value>")
 	cmd.Require(flag.Max, 1)
 
 	utils.ParseFlags(cmd, args, true)
@@ -1571,7 +1571,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 	)
 	cmd.Require(flag.Exact, 0)
 
-	cmd.Var(&flFilter, []string{"f", "-filter"}, "Provide filter values. Valid filters:\nexited=<int> - containers with exit code of <int>\nstatus=(restarting|running|paused|exited)")
+	cmd.Var(&flFilter, []string{"f", "-filter"}, "Provide filter values. Valid filters:\nexited=<int> - containers with exit code of <int>\nstatus=(restarting|running|paused|exited)\nlabel=<key> or label=<key>=<value>")
 
 	utils.ParseFlags(cmd, args, true)
 	if *last == -1 && *nLatest {

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -85,6 +85,37 @@ func maintainer(b *Builder, args []string, attributes map[string]bool, original 
 	return b.commit("", b.Config.Cmd, fmt.Sprintf("MAINTAINER %s", b.maintainer))
 }
 
+// LABEL some json data describing the image
+//
+// Sets the Label variable foo to bar,
+//
+func label(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("LABEL is missing arguments")
+	}
+	if len(args)%2 != 0 {
+		// should never get here, but just in case
+		return fmt.Errorf("Bad input to LABEL, too many args")
+	}
+
+	commitStr := "LABEL"
+
+	if b.Config.Labels == nil {
+		b.Config.Labels = map[string]string{}
+	}
+
+	for j := 0; j < len(args); j++ {
+		// name  ==> args[j]
+		// value ==> args[j+1]
+		newVar := args[j] + "=" + args[j+1] + ""
+		commitStr += " " + newVar
+
+		b.Config.Labels[args[j]] = args[j+1]
+		j++
+	}
+	return b.commit("", b.Config.Cmd, commitStr)
+}
+
 // ADD foo /path
 //
 // Add the file 'foo' to '/path'. Tarball and Remote URL (git, http) handling

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -59,6 +59,7 @@ func init() {
 	evaluateTable = map[string]func(*Builder, []string, map[string]bool, string) error{
 		"env":        env,
 		"maintainer": maintainer,
+		"label":      label,
 		"add":        add,
 		"copy":       dispatchCopy, // copy() is a go builtin
 		"from":       from,

--- a/builder/parser/line_parsers.go
+++ b/builder/parser/line_parsers.go
@@ -40,10 +40,10 @@ func parseSubCommand(rest string) (*Node, map[string]bool, error) {
 
 // parse environment like statements. Note that this does *not* handle
 // variable interpolation, which will be handled in the evaluator.
-func parseEnv(rest string) (*Node, map[string]bool, error) {
+func parseNameVal(rest string, key string) (*Node, map[string]bool, error) {
 	// This is kind of tricky because we need to support the old
-	// variant:   ENV name value
-	// as well as the new one:    ENV name=value ...
+	// variant:   KEY name value
+	// as well as the new one:    KEY name=value ...
 	// The trigger to know which one is being used will be whether we hit
 	// a space or = first.  space ==> old, "=" ==> new
 
@@ -133,10 +133,10 @@ func parseEnv(rest string) (*Node, map[string]bool, error) {
 	}
 
 	if len(words) == 0 {
-		return nil, nil, fmt.Errorf("ENV must have some arguments")
+		return nil, nil, fmt.Errorf(key + " must have some arguments")
 	}
 
-	// Old format (ENV name value)
+	// Old format (KEY name value)
 	var rootnode *Node
 
 	if !strings.Contains(words[0], "=") {
@@ -145,7 +145,7 @@ func parseEnv(rest string) (*Node, map[string]bool, error) {
 		strs := TOKEN_WHITESPACE.Split(rest, 2)
 
 		if len(strs) < 2 {
-			return nil, nil, fmt.Errorf("ENV must have two arguments")
+			return nil, nil, fmt.Errorf(key + " must have two arguments")
 		}
 
 		node.Value = strs[0]
@@ -176,6 +176,14 @@ func parseEnv(rest string) (*Node, map[string]bool, error) {
 	}
 
 	return rootnode, nil, nil
+}
+
+func parseEnv(rest string) (*Node, map[string]bool, error) {
+	return parseNameVal(rest, "ENV")
+}
+
+func parseLabel(rest string) (*Node, map[string]bool, error) {
+	return parseNameVal(rest, "LABEL")
 }
 
 // parses a whitespace-delimited set of arguments. The result is effectively a

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -50,6 +50,7 @@ func init() {
 		"workdir":    parseString,
 		"env":        parseEnv,
 		"maintainer": parseString,
+		"label":      parseLabel,
 		"from":       parseString,
 		"add":        parseMaybeJSONToList,
 		"copy":       parseMaybeJSONToList,

--- a/contrib/syntax/kate/Dockerfile.xml
+++ b/contrib/syntax/kate/Dockerfile.xml
@@ -22,6 +22,7 @@
       <item> CMD </item>
       <item> WORKDIR </item>
       <item> USER </item>
+      <item> LABEL </item>
     </list>
 
     <contexts>

--- a/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
+++ b/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
@@ -12,7 +12,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY)\s</string>
+			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|LABEL|WORKDIR|COPY)\s</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>

--- a/contrib/syntax/vim/syntax/dockerfile.vim
+++ b/contrib/syntax/vim/syntax/dockerfile.vim
@@ -11,7 +11,7 @@ let b:current_syntax = "dockerfile"
 
 syntax case ignore
 
-syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
+syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|LABEL|VOLUME|WORKDIR|COPY)\s/
 highlight link dockerfileKeyword Keyword
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -89,6 +89,10 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 			return nil
 		}
 
+		if !psFilters.MatchKVList("label", container.Config.Labels) {
+			return nil
+		}
+
 		if before != "" && !foundBefore {
 			if container.ID == beforeCont.ID {
 				foundBefore = true
@@ -151,6 +155,7 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 			out.SetInt64("SizeRw", sizeRw)
 			out.SetInt64("SizeRootFs", sizeRootFs)
 		}
+		out.SetJson("Labels", container.Config.Labels)
 		outs.Add(out)
 		return nil
 	}

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -110,6 +110,18 @@ or
   executes nothing at build time, but specifies the intended command for the
   image.
 
+**LABEL**
+ --**LABEL <key>[=<value>] [<key>[=<value>] ...]**
+
+ The **LABEL** instruction allows you to add meta-data to the image your 
+ Dockerfile is building. LABEL is specified as name value pairs. This data can
+ be retrieved using the `docker inspect` command.
+
+ The LABEL instruction allows for multiple labels to be set at one time. Like 
+ command line parsing, quotes and backslashes can be used to include spaces 
+ within values.
+
+
 **EXPOSE**
  --**EXPOSE <port> [<port>...]**
  The **EXPOSE** instruction informs Docker that the container listens on the

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -24,6 +24,8 @@ docker-create - Create a new container
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
 [**--ipc**[=*IPC*]]
+[**-l**|**--label**[=*[]*]]
+[**--label-file**[=*[]*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
 [**-m**|**--memory**[=*MEMORY*]]
@@ -100,6 +102,12 @@ IMAGE [COMMAND] [ARG...]
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+
+**-l**, **--label**=[]
+   Set meta data on the container (e.g., --label=com.example.key=value)
+
+**--label-file**=[]
+   Read in a line delimited file of labels
 
 **--link**=[]
    Add link to another container in the form of <name or id>:alias

--- a/docs/man/docker-images.1.md
+++ b/docs/man/docker-images.1.md
@@ -34,7 +34,9 @@ versions.
    Show all images (by default filter out the intermediate image layers). The default is *false*.
 
 **-f**, **--filter**=[]
-   Provide filter values (i.e., 'dangling=true')
+   Provide filter values. Valid filters:
+                          dangling=true - unlabeled images with no children
+                          label=<key> or label=<key>=<value>
 
 **--help**
   Print usage statement

--- a/docs/man/docker-inspect.1.md
+++ b/docs/man/docker-inspect.1.md
@@ -83,6 +83,11 @@ To get information on a container use it's ID or instance name:
             "Ghost": false
         },
         "Image": "df53773a4390e25936f9fd3739e0c0e60a62d024ea7b669282b27e65ae8458e6",
+        "Labels": {
+            "com.example.vendor": "Acme",
+            "com.example.license": "GPL",
+            "com.example.version": "1.0"
+        },
         "NetworkSettings": {
             "IPAddress": "172.17.0.2",
             "IPPrefixLen": 16,

--- a/docs/man/docker-ps.1.md
+++ b/docs/man/docker-ps.1.md
@@ -36,6 +36,7 @@ the running containers.
 **-f**, **--filter**=[]
    Provide filter values. Valid filters:
                           exited=<int> - containers with exit code of <int>
+                          label=<key> or label=<key>=<value>
                           status=(restarting|running|paused|exited)
 
 **-l**, **--latest**=*true*|*false*

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -25,6 +25,8 @@ docker-run - Run a command in a new container
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
 [**--ipc**[=*IPC*]]
+[**-l**|**--label**[=*[]*]]
+[**--label-file**[=*[]*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
 [**-m**|**--memory**[=*MEMORY*]]
@@ -169,6 +171,12 @@ ENTRYPOINT.
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+
+**-l**, **--label**=[]
+   Set meta data on the container (e.g., --label=com.example.key=value)
+
+**--label-file**=[]
+   Read in a line delimited file of labels
 
 **--link**=[]
    Add link to another container in the form of <name or id>:alias

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -58,6 +58,7 @@ pages:
 - ['userguide/dockerimages.md', 'User Guide', 'Working with Docker Images' ]
 - ['userguide/dockerlinks.md', 'User Guide', 'Linking containers together' ]
 - ['userguide/dockervolumes.md', 'User Guide', 'Managing data in containers' ]
+- ['userguide/labels-custom-metadata.md', 'User Guide', 'Labels - custom meta-data in Docker' ]
 - ['userguide/dockerrepos.md', 'User Guide', 'Working with Docker Hub' ]
 - ['userguide/level1.md', '**HIDDEN**' ]
 - ['userguide/level2.md', '**HIDDEN**' ]

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -58,10 +58,21 @@ to an image.  For example you could add data describing the content of an image.
 **New!**
 Docker client now hints potential proxies about connection hijacking using HTTP Upgrade headers.
 
+`POST /containers/create`
+
+**New!**
+You can set labels on container create describing the container.
+
+`GET /containers/json`
+
+**New!**
+This endpoint now returns the labels associated with each container (`Labels`).
+
 `GET /containers/(id)/json`
 
 **New!**
 This endpoint now returns the list current execs associated with the container (`ExecIDs`).
+This endpoint now returns the container labels (`Config.Labels`).
 
 `POST /containers/(id)/rename`
 
@@ -79,6 +90,11 @@ root filesystem as read only.
 
 **New!**
 This endpoint returns a stream of container stats based on resource usage.
+
+`GET /images/json`
+
+**New!**
+This endpoint now returns the labels associated with each image (`Labels`).
 
 
 ## v1.16

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -46,6 +46,13 @@ You can still call an old version of the API using
 
 ### What's new
 
+**New!**
+Build now has support for `LABEL` command which can be used to add user data
+to an image.  For example you could add data describing the content of an image.
+
+`LABEL "Vendor"="ACME Incorporated"`
+
+**New!**
 `POST /containers/(id)/attach` and `POST /exec/(id)/start`
 
 **New!**

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -50,7 +50,7 @@ You can still call an old version of the API using
 Build now has support for `LABEL` command which can be used to add user data
 to an image.  For example you could add data describing the content of an image.
 
-`LABEL "Vendor"="ACME Incorporated"`
+`LABEL "com.example.vendor"="ACME Incorporated"`
 
 **New!**
 `POST /containers/(id)/attach` and `POST /exec/(id)/start`

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -192,6 +192,7 @@ Json Parameters:
 -   **OpenStdin** - Boolean value, opens stdin,
 -   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `VAR=value`
+-   **Labels** - A list of labels that will applied in the form of `VAR=value`
 -   **Cmd** - Command to run specified as a string or an array of strings.
 -   **Entrypoint** - Set the entrypoint for the container a a string or an array
       of strings
@@ -299,6 +300,11 @@ Return low-level information on the container `id`
 			"ExposedPorts": null,
 			"Hostname": "ba033ac44011",
 			"Image": "ubuntu",
+                        "Labels": {
+                                "Vendor": "Acme",
+                                "License": "GPL",
+                                "Version": "1.0"
+                        },
 			"MacAddress": "",
 			"Memory": 0,
 			"MemorySwap": 0,
@@ -1134,7 +1140,11 @@ Return low-level information on the image `name`
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
                              "Image": "base",
-                             "Labels": null,
+                             "Labels": {
+                                    "Vendor": "Acme",
+                                    "License": "GPL",
+                                    "Version": "1.0"
+                             },
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -129,6 +129,11 @@ Create a container
              ],
              "Entrypoint": "",
              "Image": "base",
+             "Labels": {
+                     "Vendor": "Acme",
+                     "License": "GPL",
+                     "Version": "1.0"
+             },
              "Volumes": {
                      "/tmp": {}
              },
@@ -1129,6 +1134,7 @@ Return low-level information on the image `name`
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
                              "Image": "base",
+                             "Labels": null,
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -130,9 +130,9 @@ Create a container
              "Entrypoint": "",
              "Image": "base",
              "Labels": {
-                     "Vendor": "Acme",
-                     "License": "GPL",
-                     "Version": "1.0"
+                     "com.example.vendor": "Acme",
+                     "com.example.license": "GPL",
+                     "com.example.version": "1.0"
              },
              "Volumes": {
                      "/tmp": {}
@@ -192,7 +192,8 @@ Json Parameters:
 -   **OpenStdin** - Boolean value, opens stdin,
 -   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `VAR=value`
--   **Labels** - A list of labels that will applied in the form of `VAR=value`
+-   **Labels** - A map of labels and their values that will be added to the 
+        container. It should be specified in the form `{"name":"value"[,"name2":"value2"]}`
 -   **Cmd** - Command to run specified as a string or an array of strings.
 -   **Entrypoint** - Set the entrypoint for the container a a string or an array
       of strings
@@ -300,11 +301,11 @@ Return low-level information on the container `id`
 			"ExposedPorts": null,
 			"Hostname": "ba033ac44011",
 			"Image": "ubuntu",
-                        "Labels": {
-                                "Vendor": "Acme",
-                                "License": "GPL",
-                                "Version": "1.0"
-                        },
+			"Labels": {
+				"com.example.vendor": "Acme",
+				"com.example.license": "GPL",
+				"com.example.version": "1.0"
+			},
 			"MacAddress": "",
 			"Memory": 0,
 			"MemorySwap": 0,
@@ -1141,9 +1142,9 @@ Return low-level information on the image `name`
                              "Dns": null,
                              "Image": "base",
                              "Labels": {
-                                    "Vendor": "Acme",
-                                    "License": "GPL",
-                                    "Version": "1.0"
+                                 "com.example.vendor": "Acme",
+                                 "com.example.license": "GPL",
+                                 "com.example.version": "1.0"
                              },
                              "Volumes": null,
                              "VolumesFrom": "",

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -331,13 +331,23 @@ default specified in `CMD`.
 ## LABEL
    LABEL <key>=<value> <key>=<value> <key>=<value> ...
 
- --The `LABEL` instruction allows you to describe the image your `Dockerfile`
-is building. `LABEL` is specified as name value pairs. This data can
+The `LABEL` instruction allows you to add meta-data to the image your 
+`Dockerfile` is building. `LABEL` is specified as name value pairs. This data can
 be retrieved using the `docker inspect` command
 
+    LABEL com.example.label-without-value
+    LABEL com.example.label-with-value="foo"
+    LABEL version="1.0"
+    LABEL description="This my ACME image" vendor="ACME Products"
 
-    LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products"
-    LABEL Version="1.0"
+As illustrated above, the `LABEL` instruction allows for multiple labels to be
+set at one time. Like command line parsing, quotes and backslashes can be used
+to include spaces within values.
+
+For example:
+
+    LABEL description="This text illustrates \
+    that label-values can span multiple lines."
 
 ## EXPOSE
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -328,6 +328,17 @@ default specified in `CMD`.
 > the result; `CMD` does not execute anything at build time, but specifies
 > the intended command for the image.
 
+## LABEL
+   LABEL <key>=<value> <key>=<value> <key>=<value> ...
+
+ --The `LABEL` instruction allows you to describe the image your `Dockerfile`
+is building. `LABEL` is specified as name value pairs. This data can
+be retrieved using the `docker inspect` command
+
+
+    LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products"
+    LABEL Version="1.0"
+
 ## EXPOSE
 
     EXPOSE <port> [<port>...]
@@ -893,6 +904,7 @@ For example you might add something like this:
     FROM      ubuntu
     MAINTAINER Victor Vieux <victor@docker.com>
 
+    LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products" Version="1.0"
     RUN apt-get update && apt-get install -y inotify-tools nginx apache2 openssh-server
 
     # Firefox over VNC

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1044,7 +1044,9 @@ To see how the `docker:latest` image was built:
     List images
 
       -a, --all=false      Show all images (by default filter out the intermediate image layers)
-      -f, --filter=[]      Provide filter values (i.e., 'dangling=true')
+      -f, --filter=[]      Provide filter values. Valid filters:
+                             dangling=true - unlabeled images with no children
+                             label=<key> or label=<key>=<value>
       --no-trunc=false     Don't truncate output
       -q, --quiet=false    Only show numeric IDs
 
@@ -1423,6 +1425,7 @@ The `docker rename` command allows the container to be renamed to a different na
       -f, --filter=[]       Provide filter values. Valid filters:
                               exited=<int> - containers with exit code of <int>
                               status=(restarting|running|paused|exited)
+                              label=<key> or label=<key>=<value>
       -l, --latest=false    Show only the latest created container, include non-running ones.
       -n=-1                 Show n last created containers, include non-running ones.
       --no-trunc=false      Don't truncate output
@@ -1610,6 +1613,8 @@ removed before the image is removed.
       --ipc=""                   Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                    'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                    'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+      -l, --label=[]             Set meta data on a container, for example com.example.key=value
+      -label-file=[]             Read in a line delimited file of labels
       --link=[]                  Add link to another container in the form of name:alias
       --lxc-conf=[]              (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
       -m, --memory=""            Memory limit (format: <number><optional unit>, where unit = b, k, m or g)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -746,6 +746,8 @@ Creates a new container.
       --ipc=""                   Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                    'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                    'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+      -l, --label=[]             Set meta data on the container (e.g., --label=com.example.key=value)
+      --label-file=[]            Read in a line delimited file of labels
       --link=[]                  Add link to another container in the form of <name or id>:alias
       --lxc-conf=[]              (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
       -m, --memory=""            Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
@@ -1102,6 +1104,7 @@ than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "b
 
 Current filters:
  * dangling (boolean - true or false)
+ * label (`label=<key>` or `label=<key>=<value>`)
 
 ##### Untagged images
 
@@ -1424,8 +1427,8 @@ The `docker rename` command allows the container to be renamed to a different na
       --before=""           Show only container created before Id or Name, include non-running ones.
       -f, --filter=[]       Provide filter values. Valid filters:
                               exited=<int> - containers with exit code of <int>
-                              status=(restarting|running|paused|exited)
                               label=<key> or label=<key>=<value>
+                              status=(restarting|running|paused|exited)
       -l, --latest=false    Show only the latest created container, include non-running ones.
       -n=-1                 Show n last created containers, include non-running ones.
       --no-trunc=false      Don't truncate output
@@ -1613,8 +1616,8 @@ removed before the image is removed.
       --ipc=""                   Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                    'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                    'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
-      -l, --label=[]             Set meta data on a container, for example com.example.key=value
-      -label-file=[]             Read in a line delimited file of labels
+      -l, --label=[]             Set meta data on the container (e.g., --label=com.example.key=value)
+      --label-file=[]            Read in a line delimited file of labels
       --link=[]                  Add link to another container in the form of name:alias
       --lxc-conf=[]              (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
       -m, --memory=""            Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
@@ -1782,6 +1785,36 @@ An example of a file passed with `--env-file`
 
 This will create and run a new container with the container name being
 `console`.
+
+    $ sudo docker run -l my-label --env com.example.foo=bar ubuntu bash
+
+This sets two labels on the container. Label "my-label" doesn't have a value
+specified and will default to "" (empty string) for its value. Both `-l` and 
+`--env` can be repeated to add more labels. Label names are unique; if the same 
+label is specified multiple times, latter values overwrite the previous value.
+
+Labels can also be loaded from a line delimited file of labels using the 
+`--label-file` flag. The example below will load labels from a file named `labels`
+in the current directory;
+
+    $ sudo docker run --env-file ./labels ubuntu bash
+
+The format of the labels-file is similar to that used for loading environment
+variables (see `--env-file` above). An example of a file passed with `--env-file`;
+
+    $ cat ./labels
+    com.example.label1="a label"
+
+    # this is a comment
+    com.example.label2=another\ label
+    com.example.label3
+
+Multiple label-files can be loaded by providing the `--label-file` multiple 
+times.
+
+For additional information on working with labels, see 
+[*Labels - custom meta-data in Docker*](/userguide/labels-custom-metadata/) in
+the user guide.
 
     $ sudo docker run --link /redis:redis --name console ubuntu bash
 

--- a/docs/sources/userguide/labels-custom-metadata.md
+++ b/docs/sources/userguide/labels-custom-metadata.md
@@ -1,0 +1,194 @@
+page_title: Labels - custom meta-data in Docker
+page_description: Learn how to work with custom meta-data in Docker, using labels.
+page_keywords: Usage, user guide, labels, meta-data, docker, documentation, examples, annotating
+
+## Labels - custom meta-data in Docker
+
+Docker enables you to add meta-data to your images, containers, and daemons via
+labels. Meta-data can serve a wide range of uses ranging from adding notes or 
+licensing information to an image to identifying a host.
+
+Labels in Docker are implemented as `<key>` / `<value>` pairs and values are
+stored as *strings*.
+
+>**note:** Support for daemon-labels was added in docker 1.4.1, labels on
+>containers and images in docker 1.6.0
+
+### Naming your labels - namespaces
+
+Docker puts no hard restrictions on the names you pick for your labels, however,
+it's easy for labels to "conflict".
+
+For example, you're building a tool that categorizes your images in 
+architectures, doing so by using an "architecture" label;
+
+    LABEL architecture="amd64"
+
+    LABEL architecture="ARMv7"
+
+But a user decided to label images by Architectural style
+
+    LABEL architecture="Art Nouveau"
+
+To prevent such conflicts, Docker uses the convention to namespace label-names,
+using a reverse domain notation;
+
+
+- All (third-party) tools should namespace (prefix) their labels with the 
+  reverse DNS notation of a domain controlled by the author of the tool. For 
+  example, "com.example.some-label".
+- Namespaced labels should only consist of lower-cased alphanumeric characters,
+  dots and dashes (in short, `[a-z0-9-.]`), should start *and* end with an alpha
+  numeric character, and may not contain consecutive dots or dashes.
+- The `com.docker.*`, `io.docker.*` and `com.dockerproject.*` namespaces are
+  reserved for Docker's internal use.
+- Labels *without* namespace (dots) are reserved for CLI use. This allows end-
+  users to add meta-data to their containers and images, without having to type 
+  cumbersome namespaces on the command-line.
+
+
+> **Note:** Even though Docker does not *enforce* you to use namespaces,
+> preventing to do so will likely result in conflicting usage of labels. 
+> If you're building a tool that uses labels, you *should* use namespaces
+> for your labels.
+
+
+### Storing structured data in labels
+
+Labels can store any type of data, as long as its stored as a string. 
+
+
+    {
+        "Description": "A containerized foobar",
+        "Usage": "docker run --rm example/foobar [args]",
+        "License": "GPL",
+        "Version": "0.0.1-beta",
+        "aBoolean": true,
+        "aNumber" : 0.01234,
+        "aNestedArray": ["a", "b", "c"]
+    }
+
+Which can be stored in a label by serializing it to a string first;
+
+    LABEL com.example.image-specs="{\"Description\":\"A containerized foobar\",\"Usage\":\"docker run --rm example\\/foobar [args]\",\"License\":\"GPL\",\"Version\":\"0.0.1-beta\",\"aBoolean\":true,\"aNumber\":0.01234,\"aNestedArray\":[\"a\",\"b\",\"c\"]}"
+
+
+> **Note:** Although the example above shows it's *possible* to store structured 
+> data in labels, Docker does not treat this data any other way than a 'regular'
+> string. This means that Docker doesn't offer ways to query (filter) based on 
+> nested properties. If your tool needs to filter on nested properties, the 
+> tool itself should implement this.
+
+
+### Adding labels to images; the `LABEL` instruction
+
+Adding labels to your 
+
+
+    LABEL [<namespace>.]<name>[=<value>] ...
+
+The `LABEL` instruction adds a label to your image, optionally setting its value.
+Quotes surrounding name and value are optional, but required if they contain
+white space characters. Alternatively, backslashes can be used.
+
+Label values only support strings
+
+
+    LABEL vendor=ACME\ Incorporated
+    LABEL com.example.version.is-beta
+    LABEL com.example.version="0.0.1-beta"
+    LABEL com.example.release-date="2015-02-12"
+
+The `LABEL` instruction supports setting multiple labels in a single instruction
+using this notation;
+
+    LABEL com.example.version="0.0.1-beta" com.example.release-date="2015-02-12"
+
+Wrapping is allowed by using a backslash (`\`) as continuation marker;
+
+    LABEL vendor=ACME\ Incorporated \
+          com.example.is-beta \
+          com.example.version="0.0.1-beta" \
+          com.example.release-date="2015-02-12"
+
+
+You can view the labels via `docker inspect`
+
+    $ docker inspect 4fa6e0f0c678
+
+    ...
+    "Labels": {
+        "vendor": "ACME Incorporated",
+        "com.example.is-beta": "",
+        "com.example.version": "0.0.1-beta",
+        "com.example.release-date": "2015-02-12"
+    }
+    ...
+
+    $ docker inspect -f "{{json .Labels }}" 4fa6e0f0c678
+
+    {"Vendor":"ACME Incorporated","com.example.is-beta":"","com.example.version":"0.0.1-beta","com.example.release-date":"2015-02-12"}
+
+> **note:** We recommend combining labels in a single `LABEl` instruction in
+> stead of using a `LABEL` instruction for each label. Each instruction in a
+> Dockerfile produces a new layer, which can result in an inefficient image if
+> many labels are used.
+
+### Querying labels
+
+Besides storing meta-data, labels can be used to filter your images and 
+containers.
+
+List all running containers that have a `com.example.is-beta` label;
+
+    # List all running containers that have a `com.example.is-beta` label
+    $ docker ps --filter "label=com.example.is-beta"
+
+
+List all running containers with a "color" label set to "blue";
+
+    $ docker ps --filter "label=color=blue"
+
+List all images with "vendor" "ACME"
+
+    $ docker images --filter "label=vendor=ACME"
+
+
+### Daemon labels
+
+
+
+    docker -d \
+      --dns 8.8.8.8 \
+      --dns 8.8.4.4 \
+      -H unix:///var/run/docker.sock \
+      --label com.example.environment="production" \
+      --label com.example.storage="ssd"
+
+And can be seen as part of the `docker info` output for the daemon;
+
+    docker -D info
+    Containers: 12
+    Images: 672
+    Storage Driver: aufs
+     Root Dir: /var/lib/docker/aufs
+     Backing Filesystem: extfs
+     Dirs: 697
+    Execution Driver: native-0.2
+    Kernel Version: 3.13.0-32-generic
+    Operating System: Ubuntu 14.04.1 LTS
+    CPUs: 1
+    Total Memory: 994.1 MiB
+    Name: docker.example.com
+    ID: RC3P:JTCT:32YS:XYSB:YUBG:VFED:AAJZ:W3YW:76XO:D7NN:TEVU:UCRW
+    Debug mode (server): false
+    Debug mode (client): true
+    Fds: 11
+    Goroutines: 14
+    EventsListeners: 0
+    Init Path: /usr/bin/docker
+    Docker Root Dir: /var/lib/docker
+    WARNING: No swap limit support
+    Labels:
+     com.example.environment=production
+     com.example.storage=ssd

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4310,6 +4310,28 @@ func TestBuildWithTabs(t *testing.T) {
 	logDone("build - with tabs")
 }
 
+func TestBuildLabels(t *testing.T) {
+	name := "testbuildlabel"
+	expected := `{"License":"GPL","Vendor":"Acme"}`
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		`FROM busybox
+		LABEL Vendor=Acme
+                LABEL License GPL`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := inspectFieldJSON(name, "Config.Labels")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != expected {
+		t.Fatalf("Labels %s, expected %s", res, expected)
+	}
+	logDone("build - label")
+}
+
 func TestBuildStderr(t *testing.T) {
 	// This test just makes sure that no non-error output goes
 	// to stderr

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/docker/docker/nat"
 	"os"
 	"os/exec"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -244,4 +245,58 @@ func TestCreateVolumesCreated(t *testing.T) {
 	}
 
 	logDone("create - volumes are created")
+}
+
+func TestCreateLabels(t *testing.T) {
+	name := "test_create_labels"
+	expected := map[string]string{"k1": "v1", "k2": "v2"}
+	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "create", "--name", name, "-l", "k1=v1", "--label", "k2=v2", "busybox")); err != nil {
+		t.Fatal(out, err)
+	}
+
+	actual := make(map[string]string)
+	err := inspectFieldAndMarshall(name, "Config.Labels", &actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected %s got %s", expected, actual)
+	}
+
+	deleteAllContainers()
+
+	logDone("create - labels")
+}
+
+func TestCreateLabelFromImage(t *testing.T) {
+	imageName := "testcreatebuildlabel"
+	defer deleteImages(imageName)
+	_, err := buildImage(imageName,
+		`FROM busybox
+		LABEL k1=v1 k2=v2`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	name := "test_create_labels_from_image"
+	expected := map[string]string{"k2": "x", "k3": "v3", "k1": "v1"}
+	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "create", "--name", name, "-l", "k2=x", "--label", "k3=v3", imageName)); err != nil {
+		t.Fatal(out, err)
+	}
+
+	actual := make(map[string]string)
+	err = inspectFieldAndMarshall(name, "Config.Labels", &actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected %s got %s", expected, actual)
+	}
+
+	deleteAllContainers()
+
+	logDone("create - labels from image")
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -397,6 +397,54 @@ func TestPsListContainersFilterName(t *testing.T) {
 	logDone("ps - test ps filter name")
 }
 
+func TestPsListContainersFilterLabel(t *testing.T) {
+	// start container
+	runCmd := exec.Command(dockerBinary, "run", "-d", "-l", "match=me", "busybox")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatal(out, err)
+	}
+	firstID := stripTrailingCharacters(out)
+
+	// start another container
+	runCmd = exec.Command(dockerBinary, "run", "-d", "-l", "match=me too", "busybox")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	secondID := stripTrailingCharacters(out)
+
+	// start third container
+	runCmd = exec.Command(dockerBinary, "run", "-d", "-l", "nomatch=me", "busybox")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	thirdID := stripTrailingCharacters(out)
+
+	// filter containers by exact match
+	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	containerOut := strings.TrimSpace(out)
+	if containerOut != firstID {
+		t.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID, containerOut, out)
+	}
+
+	// filter containers by exact key
+	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--no-trunc", "--filter=label=match")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	containerOut = strings.TrimSpace(out)
+	if (!strings.Contains(containerOut, firstID) || !strings.Contains(containerOut, secondID)) || strings.Contains(containerOut, thirdID) {
+		t.Fatalf("Expected ids %s,%s, got %s for exited filter, output: %q", firstID, secondID, containerOut, out)
+	}
+
+	deleteAllContainers()
+
+	logDone("ps - test ps filter label")
+}
+
 func TestPsListContainersFilterExited(t *testing.T) {
 	defer deleteAllContainers()
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -607,6 +607,15 @@ func inspectFieldJSON(name, field string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+func inspectFieldAndMarshall(name, field string, output interface{}) error {
+	str, err := inspectFieldJSON(name, field)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal([]byte(str), output)
+}
+
 func inspectFieldMap(name, path, field string) (string, error) {
 	format := fmt.Sprintf("{{index .%s %q}}", path, field)
 	inspectCmd := exec.Command(dockerBinary, "inspect", "-f", format, name)

--- a/pkg/parsers/filters/parse.go
+++ b/pkg/parsers/filters/parse.go
@@ -65,6 +65,35 @@ func FromParam(p string) (Args, error) {
 	return args, nil
 }
 
+func (filters Args) MatchKVList(field string, sources map[string]string) bool {
+	fieldValues := filters[field]
+
+	//do not filter if there is no filter set or cannot determine filter
+	if len(fieldValues) == 0 {
+		return true
+	}
+
+	if sources == nil {
+		return false
+	}
+
+	for _, name2match := range fieldValues {
+		testKV := strings.SplitN(name2match, "=", 2)
+
+		for k, v := range sources {
+			if len(testKV) == 1 {
+				if k == testKV[0] {
+					return true
+				}
+			} else if k == testKV[0] && v == testKV[1] {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func (filters Args) Match(field, source string) bool {
 	fieldValues := filters[field]
 

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
+	SecurityOpt     []string
+	Labels          map[string]string
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {
@@ -66,6 +68,9 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 	if Cmd := job.GetenvList("Cmd"); Cmd != nil {
 		config.Cmd = Cmd
 	}
+
+	job.GetenvJson("Labels", &config.Labels)
+
 	if Entrypoint := job.GetenvList("Entrypoint"); Entrypoint != nil {
 		config.Entrypoint = Entrypoint
 	}

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -84,6 +84,16 @@ func Merge(userConf, imageConf *Config) error {
 		}
 	}
 
+	if userConf.Labels == nil {
+		userConf.Labels = map[string]string{}
+	}
+	if imageConf.Labels != nil {
+		for l := range userConf.Labels {
+			imageConf.Labels[l] = userConf.Labels[l]
+		}
+		userConf.Labels = imageConf.Labels
+	}
+
 	if len(userConf.Entrypoint) == 0 {
 		if len(userConf.Cmd) == 0 {
 			userConf.Cmd = imageConf.Cmd


### PR DESCRIPTION
Adds more documentation for labels and adds the label instruction to the man-pages.

Also included is a document called "Labels - custom meta-data in Docker" in the user-guide,
this is still a work-in-progress I started to describe the "namespaces" conventions, an example on
storing structured data.

I ran a bit "out of steam" (writers block?) on that document, but kept it in (for now), in case
it still ends up useful.

The Remote API documentation changes will need to be moved to the docker_remote_api_v1.18.md document when rebasing the whole PR.
